### PR TITLE
Fixing Momentjs deprecation warning

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -315,7 +315,7 @@
                     start = this.minDate.clone();
 
                 var maxDate = this.maxDate;
-                if (this.dateLimit && start.clone().add(this.dateLimit).isAfter(maxDate))
+                if (this.dateLimit && maxDate && start.clone().add(this.dateLimit).isAfter(maxDate))
                     maxDate = start.clone().add(this.dateLimit);
                 if (maxDate && end.isAfter(maxDate))
                     end = maxDate.clone();


### PR DESCRIPTION
When you configure the date range with Predefined Ranges and a dateLimit, momentjs shows a  deprecation warning because in the line 318 we have this:
_**this.dateLimit && start.clone().add(this.dateLimit).isAfter(maxDate)**_
In this specific case **maxDate** is false